### PR TITLE
Add options to run garbage collection and ignore repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 MANIFEST
 dist
+*.py?

--- a/clonehub
+++ b/clonehub
@@ -12,6 +12,10 @@ def backup_all(user):
     repos = github.repos(user)
     for repo in repos:
         local = repo['name']
+        if args.ignore and local in args.ignore:
+            print ' - Ignoring %s' % local
+            continue
+
         if not args.checkout:
             local = local + '.git'
 
@@ -25,11 +29,18 @@ def backup_all(user):
         else:
             git.clone(url, args.checkout)
 
+        if args.garbage_collect:
+            git.gc(local)
+
 def backup_mine():
     print 'Backing up all accessible repos, including private ones'
     repos = github.my_repos()
     for repo in repos:
         local = repo['full_name']
+        if args.ignore and repo['name'] in args.ignore:
+            print ' - Ignoring %s' % local
+            continue
+
         if not args.checkout:
             local = local + '.git'
 
@@ -39,10 +50,15 @@ def backup_mine():
         else:
             git.clone(url, local, args.checkout)
 
+        if args.garbage_collect:
+            git.gc(local)
+
 parser = argparse.ArgumentParser()
 parser.add_argument('users', help='A user to back up repos for; empty for all accessible', metavar='USER', nargs='*')
 parser.add_argument('-s', '--ssh', help='Clone using SSH instead of anonymous HTTPS', action='store_true')
 parser.add_argument('-c', '--checkout', help='Clone to a regular repository instead of a bare one', action='store_true')
+parser.add_argument('-g', '--garbage-collect', help='Garbage collect repository after clone', action='store_true')
+parser.add_argument('-i', '--ignore', help='Ignore REPO. Can be specified multiple times', metavar='REPO', action='append')
 parser.parse_args()
 args = parser.parse_args()
 

--- a/git.py
+++ b/git.py
@@ -28,3 +28,7 @@ def clone(repo, dst, checkout=False):
         mirror = '--mirror'
     _command('git clone %s %s %s' % (mirror, repo, dst))
 
+
+def gc(repo):
+    print ' . Garbage collecting %s' % repo
+    _command('cd %s ; git gc' % repo)


### PR DESCRIPTION
* Add option to run `git gc` on repos after clone. This can compress
  active repos but could increase backup when doing incremental backups.

* Add option to ignore repo.  It takes just the repo name without user.
  Can be specified multiple times to ignore multiple repos. This is
  useful on repos that are forks and don't really need to be backed up.

* Also ignore compiled python files